### PR TITLE
Small update to the edex connection window

### DIFF
--- a/viz/com.raytheon.uf.viz.core/src/com/raytheon/uf/viz/core/localization/ConnectivityPreferenceDialog.java
+++ b/viz/com.raytheon.uf.viz.core/src/com/raytheon/uf/viz/core/localization/ConnectivityPreferenceDialog.java
@@ -323,10 +323,10 @@ public class ConnectivityPreferenceDialog {
         gd.horizontalIndent = 20;
         localizationLabel.setLayoutData(gd);
 
+        String unidataUrl = "edex-cloud.unidata.ucar.edu";
         String[] pastOptions =  {
         		"localhost",
-        		"edex",
-        		"edex-cloud.unidata.ucar.edu"
+        		unidataUrl
         		};
         String[] serverOptions = getServerOptions();
 
@@ -335,7 +335,7 @@ public class ConnectivityPreferenceDialog {
         gd.minimumWidth = 300;
         localizationSrv.widget.setLayoutData(gd);
         localization = shortServerName(localization);
-        localizationSrv.setText(localization == null ? "" : localization);
+        localizationSrv.setText(localization == null || localization.equals("") ? unidataUrl : localization);
         localizationSrv.addSelectionListener(new SelectionListener() {
             @Override
             public void widgetSelected(SelectionEvent e) {


### PR DESCRIPTION
- removed the "edex" option
- set the default to "edex-cloud.unidata.ucar.edu" if the previous setting is null or empty string