### PR TITLE
Replaced instances of "Bundle" in CAVE GUI:

### DIFF
--- a/viz/com.raytheon.viz.ui/src/com/raytheon/viz/ui/actions/OpenPerspectiveFileListDlg.java
+++ b/viz/com.raytheon.viz.ui/src/com/raytheon/viz/ui/actions/OpenPerspectiveFileListDlg.java
@@ -87,7 +87,7 @@ public class OpenPerspectiveFileListDlg extends VizOpenLocalizationFileListDlg {
      * @param localizationDirectory
      */
     public OpenPerspectiveFileListDlg(Shell parent, String localizationDirectory) {
-        super("Open Bundle", parent, localizationDirectory,
+        super("Open Display", parent, localizationDirectory,
                 "perspectives", LocalizationType.COMMON_STATIC);
     }
 

--- a/viz/com.raytheon.viz.ui/src/com/raytheon/viz/ui/actions/SavePerspectiveHandler.java
+++ b/viz/com.raytheon.viz.ui/src/com/raytheon/viz/ui/actions/SavePerspectiveHandler.java
@@ -102,7 +102,7 @@ public class SavePerspectiveHandler
         if (this.saveAsDlg == null || this.saveAsDlg.getShell() == null
                 || this.saveAsDlg.isDisposed()) {
             saveAsDlg = new PerspectiveFileListDlg(
-                    "Save Bundle", shell,
+                    "Save Display", shell,
                     VizLocalizationFileListDlg.Mode.SAVE, PERSPECTIVES_DIR);
             saveAsDlg.addCloseCallback(new ICloseCallback() {
 


### PR DESCRIPTION
- Changed "Open/Save Bundle" to "Open/Save Display"