### PR TITLE
Added a special import for reduce to fix an issue with Upper Air RAOB…

### DIFF
--- a/common/com.raytheon.uf.common.derivparam.python/utility/common_static/base/derivedParameters/functions/Add.py
+++ b/common/com.raytheon.uf.common.derivparam.python/utility/common_static/base/derivedParameters/functions/Add.py
@@ -19,7 +19,7 @@
 ##
 
 from numpy import add,array,zeros_like
-
+from functools import reduce
 import Vector
 
 def execute(*args):

--- a/common/com.raytheon.uf.common.derivparam.python/utility/common_static/base/derivedParameters/functions/Multiply.py
+++ b/common/com.raytheon.uf.common.derivparam.python/utility/common_static/base/derivedParameters/functions/Multiply.py
@@ -19,6 +19,7 @@
 ##
 
 from numpy import multiply
+from functools import reduce
 import Vector
 
 def execute(*args):


### PR DESCRIPTION
… plots not loading on Windows that works with python2 and 3 for the Add.py and Multiple.py derived parameter functions.