### PR TITLE
Transition from ufpy to awips python package

### DIFF
--- a/common/com.raytheon.uf.common.dataaccess/pythonPackages/dynamicserialize/dstypes/com/raytheon/uf/common/dataaccess/impl/DefaultDataRequest.py
+++ b/common/com.raytheon.uf.common.dataaccess/pythonPackages/dynamicserialize/dstypes/com/raytheon/uf/common/dataaccess/impl/DefaultDataRequest.py
@@ -31,7 +31,7 @@
 #
 
 
-from ufpy.dataaccess import IDataRequest
+from awips.dataaccess import IDataRequest
 
 from dynamicserialize.dstypes.org.locationtech.jts.geom import Envelope
 from dynamicserialize.dstypes.com.raytheon.uf.common.dataplugin.level import Level

--- a/common/com.raytheon.uf.common.dataaccess/pythonPackages/dynamicserialize/dstypes/com/raytheon/uf/common/dataaccess/impl/DefaultNotificationFilter.py
+++ b/common/com.raytheon.uf.common.dataaccess/pythonPackages/dynamicserialize/dstypes/com/raytheon/uf/common/dataaccess/impl/DefaultNotificationFilter.py
@@ -31,7 +31,7 @@
 #
 
 
-from ufpy.dataaccess import INotificationFilter
+from awips.dataaccess import INotificationFilter
 import sys
 
 class DefaultNotificationFilter(INotificationFilter):


### PR DESCRIPTION
-Update multiple python scripts across several repos to use awips instead of ufpy:
   -awips2
   -awips2-core
   -awips2-nativelib
   -awips2-ncep
   -awips2-rpm