### PR TITLE
Increase the edex_camel@request max memory to 8GB

### DIFF
--- a/common/com.raytheon.uf.common.dataaccess/src/com/raytheon/uf/common/dataaccess/impl/AbstractDataFactory.java
+++ b/common/com.raytheon.uf.common.dataaccess/src/com/raytheon/uf/common/dataaccess/impl/AbstractDataFactory.java
@@ -81,7 +81,7 @@ public abstract class AbstractDataFactory implements IDataFactory {
 
     /** The maximum response size, in bytes. */
     public static final long MAX_RESPONSE_SIZE = Long.getLong(RESPONSE_PROP,
-            100L) * SizeUtil.BYTES_PER_MB;
+            400L) * SizeUtil.BYTES_PER_MB;
 
     protected static final String[] EMPTY = new String[0];
 

--- a/edex/com.raytheon.uf.edex.requestsrv/esb/etc/request.sh
+++ b/edex/com.raytheon.uf.edex.requestsrv/esb/etc/request.sh
@@ -32,7 +32,7 @@
 export MAX_MEM=2304 # in Meg
 
 if [ $HIGH_MEM == "on" ]; then
-    export MAX_MEM=4096
+    export MAX_MEM=8192
 fi
 
 export SERIALIZE_POOL_MAX_SIZE=24


### PR DESCRIPTION
We were getting a number of edex_camel@request restarts due to java out of memory errors. I have increased the allowed max memory from 2GB to 8GB. In the wrapper.conf (awips2 repo) the timeout was also increased from 320ms to 600ms.

https://github.com/Unidata/awips-unidata-builds/issues/191