### PR TITLE
Had to set unpack="false" for feature files that referenced org.apach…

### DIFF
--- a/features/com.raytheon.uf.common.base.feature/feature.xml
+++ b/features/com.raytheon.uf.common.base.feature/feature.xml
@@ -304,7 +304,7 @@
    <plugin
          id="org.apache.xerces"
          version="2.12.2"
-         unpack="true"/>
+         unpack="false"/>
 
    <plugin
          id="com.raytheon.uf.common.convert"

--- a/features/com.raytheon.uf.viz.base.feature/feature.xml
+++ b/features/com.raytheon.uf.viz.base.feature/feature.xml
@@ -290,7 +290,7 @@
          download-size="0"
          install-size="0"
          version="2.12.2"
-         unpack="true"/>
+         unpack="false"/>
 
    <plugin
          id="com.raytheon.uf.viz.auth"

--- a/viz/com.raytheon.uf.viz.application.feature/feature.xml
+++ b/viz/com.raytheon.uf.viz.application.feature/feature.xml
@@ -381,7 +381,7 @@
          download-size="0"
          install-size="0"
          version="0.0.0"
-         unpack="true"/>
+         unpack="false"/>
 
          <plugin
          id="org.apache.commons.digester"


### PR DESCRIPTION
…e.xerces

When building CAVE RPM's I was getting an error that it was looking for the directory instead of the jar file, so I specified it to not be packed (jar'd up)

https://github.com/Unidata/awips-unidata-builds/issues/212