### PR TITLE
Set the version to generic 0.0.0 for org.apache.commons.commons-io

### DIFF
--- a/viz/com.raytheon.uf.viz.application.feature/feature.xml
+++ b/viz/com.raytheon.uf.viz.application.feature/feature.xml
@@ -54,7 +54,7 @@
          id="org.apache.commons.commons-io"
          download-size="0"
          install-size="0"
-         version="2.15.1"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.commons.logging"


### PR DESCRIPTION
- This mainly affects the Mac and Windows builds (when exporting from Eclipse), but it's good to have in all branches